### PR TITLE
Fix a wrong conversion of an escaped char in search pattern

### DIFF
--- a/helm-codesearch.el
+++ b/helm-codesearch.el
@@ -393,8 +393,8 @@ specifiy the file scope with -f."
 'import android' -> '('import android')"
   (let ((tokens (split-string text-pattern)))
     (if (string= (car tokens) "-f")
-        (list "-f" (nth 1 tokens) (combine-and-quote-strings (nthcdr 2 tokens) ".*"))
-      (list (combine-and-quote-strings tokens ".*")))))
+        (list "-f" (nth 1 tokens) (mapconcat 'identity (nthcdr 2 tokens) " "))
+      (list (mapconcat 'identity tokens " ")))))
 
 (defun helm-codesearch-find-file-process ()
   "Execute the csearch for a file."


### PR DESCRIPTION
The patch a48a0c4d introduced a bug converting an escaped char
'\' in search pattern to a quoted string '\\', thus making
the intended search fail. Choice of a function for joining
string |combine-and-quote-strings| caused the bug:

(combine-and-quote-strings '("-f" "java" "android\\."))
-> "-f java "android\\."

This CL replaces it with the one doing the intended conversion:

(mapconcat 'identity '("-f" "java" "android\\.") " ")
-> "-f java android\."