### PR TITLE
A defcustom for force-overwriting search results

### DIFF
--- a/helm-codesearch.el
+++ b/helm-codesearch.el
@@ -85,6 +85,11 @@
   :group 'helm-codesearch
   :type '(alist :key-type string :value-type function))
 
+(defcustom helm-codesearch-overwrite-search-result nil
+  "Overwrite search result buffer without asking confirmation."
+  :type 'boolean
+  :group 'helm-codesearch)
+
 (defvar helm-codesearch-buffer "*helm codesearch*")
 (defvar helm-codesearch-indexing-buffer "*helm codesearch indexing*")
 (defvar helm-codesearch-file nil)
@@ -270,7 +275,8 @@
         new-buf
         (pattern (with-helm-buffer helm-input-local))
         (src-name (assoc-default 'name (helm-get-current-source))))
-    (when (get-buffer buf)
+    (when (and (get-buffer buf)
+               (not helm-codesearch-overwrite-search-result))
       (setq new-buf (helm-read-string "GrepBufferName: " buf))
       (cl-loop for b in (helm-buffer-list)
                when (and (string= new-buf b)

--- a/helm-codesearch.el
+++ b/helm-codesearch.el
@@ -393,8 +393,8 @@ specifiy the file scope with -f."
 'import android' -> '('import android')"
   (let ((tokens (split-string text-pattern)))
     (if (string= (car tokens) "-f")
-        (list "-f" (nth 1 tokens) (mapconcat 'identity (nthcdr 2 tokens) " "))
-      (list (mapconcat 'identity tokens " ")))))
+        (list "-f" (nth 1 tokens) (combine-and-quote-strings (nthcdr 2 tokens) ".*"))
+      (list (combine-and-quote-strings tokens ".*")))))
 
 (defun helm-codesearch-find-file-process ()
   "Execute the csearch for a file."

--- a/helm-codesearch.el
+++ b/helm-codesearch.el
@@ -393,8 +393,8 @@ specifiy the file scope with -f."
 'import android' -> '('import android')"
   (let ((tokens (split-string text-pattern)))
     (if (string= (car tokens) "-f")
-        (list "-f" (nth 1 tokens) (combine-and-quote-strings (nthcdr 2 tokens) ".*"))
-      (list (combine-and-quote-strings tokens ".*")))))
+        (list "-f" (nth 1 tokens) (mapconcat 'identity (nthcdr 2 tokens) " "))
+      (list (mapconcat 'identity tokens " ")))))
 
 (defun helm-codesearch-find-file-process ()
   "Execute the csearch for a file."


### PR DESCRIPTION
Hi,

In many occasions,  previous results are not useful any more and can simply be overwritten by a new one. I find that the keystrokes to go through checking accidental overwrite (ENTER -> yes) stops me, making me feel interrupted.  I want to make my mental flow here a bit more smooth by allowing for force-overwrite with a new defcustom.  It is NIL by default so only takes effect when customized.  Would you take a look? Thanks.